### PR TITLE
Fix trailing comma in VSCode extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "charliermarsh.ruff",
-        "usernamehw.errorlens",
+        "usernamehw.errorlens"
     ]
 }


### PR DESCRIPTION
## Summary
- fix invalid JSON in `.vscode/extensions.json` so extension recommendations load correctly

## Testing
- `pre-commit run --files .vscode/extensions.json`


------
https://chatgpt.com/codex/tasks/task_e_68b131a314cc833091c3ae359d77fe73