### PR TITLE
chore: ignore S101 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "D104"]
-"tests/*" = ["D"]
+"tests/*" = ["D", "S101"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
## Summary
- allow assert statements in tests by ignoring S101

## Testing
- `pytest`
- `pre-commit run --files pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b151fd0ad083308349ef8a59db6c6b